### PR TITLE
Add vector map showing isochrone walking distances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 scripts/
 env/
 stadfangaskra/
+map/cache/

--- a/map/Makefile
+++ b/map/Makefile
@@ -90,5 +90,5 @@ tile_cache:
 .PHONY: tile_cache
 
 static:
-	python3 -m http.server
+	python3 -m http.server 8090
 .PHONY: static

--- a/map/Makefile
+++ b/map/Makefile
@@ -6,7 +6,7 @@ PGSUPERUSER ?= postgres
 OGR_DSN ?= PG:"dbname='$(PGDATABASE)' host='$(PGHOST)' port='$(PGPORT)' user='$(PGUSER)' password='$(PGPASSWORD)'"
 PG_DRIVER_OPTIONS ?= -f PostgreSQL -t_srs epsg:3857 -makevalid -overwrite -lco FID=id -lco PRECISION=NO -lco GEOMETRY_NAME=geom
 
-all: clean database data_cache db_tables
+all: clean database clear_cache clear_data_cache clear_tile_cache cache data_cache db_tables
 .PHONY: all
 
 ##### CACHE ############################################################################

--- a/map/Makefile
+++ b/map/Makefile
@@ -1,0 +1,94 @@
+PGDATABASE ?= election2021
+PGHOST ?= localhost
+PGPORT ?= 5432
+PGUSER ?= election2021
+PGSUPERUSER ?= postgres
+OGR_DSN ?= PG:"dbname='$(PGDATABASE)' host='$(PGHOST)' port='$(PGPORT)' user='$(PGUSER)' password='$(PGPASSWORD)'"
+PG_DRIVER_OPTIONS ?= -f PostgreSQL -t_srs epsg:3857 -makevalid -overwrite -lco FID=id -lco PRECISION=NO -lco GEOMETRY_NAME=geom
+
+all: clean database data_cache db_tables
+.PHONY: all
+
+##### CACHE ############################################################################
+
+.PHONY: clean
+clean: clear_cache
+	dropdb --if-exists --host ${PGHOST} --port ${PGPORT} --user ${PGSUPERUSER} ${PGDATABASE}
+	dropuser --if-exists --host ${PGHOST} --port ${PGPORT} --user ${PGSUPERUSER} ${PGUSER}
+
+cache:
+	mkdir -p cache/data
+.PHONY: cache
+
+clear_cache:
+	rm -rf cache
+.PHONY: clear_cache
+
+clear_data_cache:
+	rm -rf cache/data
+.PHONY: clear_data_cache
+
+clear_tile_cache:
+	rm -rf cache/tiles
+.PHONY: clear_tile_cache
+
+data_cache: cache/data/coastline.gpkg cache/data/roads.gpkg cache/data/constituencies.gpkg
+.PHONY: data_cache
+
+cache/data/coastline.gpkg:
+	curl --silent https://atlas.lmi.is/heikir/downloadData/is_50v_strandlina_isn2016_lambert_2016_gpkg.zip | funzip > cache/data/coastline.gpkg
+
+cache/data/roads.gpkg:
+	curl --silent https://atlas.lmi.is/heikir/downloadData/is_50v_samgongur_isn2016_lambert_2016_gpkg.zip | funzip > cache/data/roads.gpkg
+
+cache/data/constituencies.gpkg:
+	curl --silent https://atlas.lmi.is/heikir/downloadData/is_50v_mork_isn2016_lambert_2016_gpkg.zip | funzip > cache/data/constituencies.gpkg
+
+##### DATABASE #########################################################################
+
+.PHONY: database
+database:
+	createuser --host ${PGHOST} --port ${PGPORT} --user ${PGSUPERUSER} ${PGUSER}
+	createdb --owner ${PGUSER} --host ${PGHOST} --port ${PGPORT} --user ${PGSUPERUSER} ${PGDATABASE}
+	psql  --host ${PGHOST} --port ${PGPORT} --user ${PGSUPERUSER} ${PGDATABASE} --command "CREATE EXTENSION IF NOT EXISTS postgis"
+
+db_tables: coastline_db_table roads_db_table isochrones_db_table polling_places_db_table districts_db_table
+.PHONY: db_tables
+
+coastline_db_table: cache/data/coastline.gpkg
+	ogr2ogr ${PG_DRIVER_OPTIONS} ${OGR_DSN} cache/data/coastline.gpkg -nln coastline strandlina_flakar
+.PHONY: coastline_db_table
+
+roads_db_table: cache/data/roads.gpkg
+	ogr2ogr ${PG_DRIVER_OPTIONS} ${OGR_DSN} cache/data/roads.gpkg -nln roads samgongur_linur
+.PHONY: roads_db_table
+
+constituencies_db_table: cache/data/constituencies.gpkg
+	ogr2ogr ${PG_DRIVER_OPTIONS} ${OGR_DSN} cache/data/constituencies.gpkg -nln constituencies mork_kjordaemi
+.PHONY: constituencies_db_table
+
+isochrones_db_table:
+	ogr2ogr ${PG_DRIVER_OPTIONS} ${OGR_DSN} ../isochrones/isochrones_clipped.geojson -nln isochrones
+.PHONY: isochrones_db_table
+
+polling_places_db_table:
+	ogr2ogr ${PG_DRIVER_OPTIONS} ${OGR_DSN} ../docs/kjorstadir2021.json -nln polling_places -s_srs EPSG:4326
+.PHONY: polling_places_db_table
+
+districts_db_table:
+	ogr2ogr ${PG_DRIVER_OPTIONS} ${OGR_DSN} ../sveitarfélög/sveitarfelog.geojson -nln districts
+.PHONY: districts_db_table
+
+##### TILESERVER #######################################################################
+
+server:
+	tegola serve --config=election2021.toml
+.PHONY: server
+
+tile_cache:
+	tegola cache seed --config=election2021.toml --min-zoom 5 --max-zoom 12
+.PHONY: tile_cache
+
+static:
+	python3 -m http.server
+.PHONY: static

--- a/map/README.md
+++ b/map/README.md
@@ -1,0 +1,38 @@
+# Kjörstaðir 2021
+
+A tiled vector map showing isochrone walking distances to polling places used in the [2021 Icelandic parliamentary election](https://en.wikipedia.org/wiki/2021_Icelandic_parliamentary_election). Uses [MapLibre GL JS](https://maplibre.org/maplibre-gl-js-docs/api/) to display the map, [Tegola](https://tegola.io/) to render the tiles, and [GDAL/OGR](https://gdal.org/) to import the data into a [PostGIS](https://postgis.net/) database. To run the map locally:
+
+1. [Install Tegola](https://tegola.io/documentation/getting-started/#1-download-tegola)
+2. [Install GDAL/OGR](https://ljvmiranda921.github.io/notebook/2019/04/13/install-gdal/)
+3. [Install PostgreSQL](https://www.postgresqltutorial.com/install-postgresql/) and the [PostGIS extension](https://postgis.net/docs/postgis_installation.html), or have a remote PostgreSQL/PostGIS database available
+4. From the `map/` subdirectory, run `make`
+5. Run `make server` to run the Tegola tile server
+6. In another terminal window, run `make static` from within the `map/` subdirectory to serve the static HTML
+
+Now you can visit <http://localhost:8000/> in your browser to see the map.
+
+## Environment variables
+
+You can set several environment variables to tell Make about your database.
+
+- `PGDATABASE`: database name (default to `election2021`)
+- `PGHOST`: PostgreSQL database host (defaults to `localhost`)
+- `PGPORT`: port to use on the database host to connect to PostgreSQL (defaults to `5432`)
+- `PGUSER`: user to use to connect to the PostgreSQL database (defaults to `election2021`)
+- `PGSUPERUSER`: privileged user used to create the database and user (defaults to `postgres`)
+
+## Troubleshooting
+
+If you see an error like this when you run `make`:
+
+```
+dropdb: error: could not connect to database template1: FATAL:  role "postgres" does not exist
+```
+
+It means your root database user (required to create the `election2021` database) isn't named `postgres`. Find out what your PostgreSQL root user is called and then run:
+
+```sh
+PGSUPERUSER=foo make
+```
+
+Where `foo` is the root username.

--- a/map/README.md
+++ b/map/README.md
@@ -9,7 +9,7 @@ A tiled vector map showing isochrone walking distances to polling places used in
 5. Run `make server` to run the Tegola tile server
 6. In another terminal window, run `make static` from within the `map/` subdirectory to serve the static HTML
 
-Now you can visit <http://localhost:8000/> in your browser to see the map.
+Now you can visit <http://localhost:8090/> in your browser to see the map.
 
 ## Environment variables
 

--- a/map/election2021.toml
+++ b/map/election2021.toml
@@ -1,0 +1,243 @@
+[cache]
+type = "file"
+basepath = "./map/cache/tiles"
+max_zoom = 12
+
+[[providers]]
+name = "election2021"
+type = "postgis"
+host = "localhost"
+port = 5432
+database = "election2021"
+user = "election2021"
+password = ""
+srid = 3857
+
+[[providers.layers]]
+name = "coastline"
+geometry_fieldname = "geom"
+geometry_type = "Polygon"
+dont_simplify = true
+id_fieldname = "id"
+sql = """
+  SELECT
+    id,
+    ST_AsBinary(
+      ST_SimplifyPreserveTopology(
+        geom,
+        CASE !ZOOM!
+          WHEN  5 THEN  1500
+          WHEN  6 THEN  1000
+          WHEN  7 THEN   350
+          WHEN  8 THEN   200
+          WHEN  9 THEN   100
+          WHEN 10 THEN    50
+          WHEN 11 THEN    25
+          WHEN 12 THEN    15
+        END
+      )
+    )
+      AS geom
+  FROM
+    coastline
+  WHERE
+    geom && !BBOX!
+"""
+
+[[providers.layers]]
+name = "roads"
+geometry_fieldname = "geom"
+geometry_type = "LineString"
+dont_simplify = true
+id_fieldname = "id"
+sql = """
+  SELECT
+    id,
+    vegnr
+      AS ref,
+    ST_AsBinary(
+      ST_Simplify(
+        geom,
+        CASE !ZOOM!
+          WHEN  5 THEN 2500
+          WHEN  6 THEN 2000
+          WHEN  7 THEN  800
+          WHEN  8 THEN  400
+          WHEN  9 THEN  200
+          WHEN 10 THEN  100
+          WHEN 11 THEN   50
+          WHEN 12 THEN   0
+        END
+      )
+    )
+      AS geom
+  FROM
+    roads
+  WHERE
+    geom && !BBOX!
+    AND (
+      !ZOOM! >= 6 AND vegflokkun = '1'
+      OR
+      !ZOOM! >= 9 AND vegflokkun IN ('2', '3', '4')
+      OR
+      !ZOOM! >= 11 AND vegflokkun = '5'
+      OR
+      !ZOOM! >= 12 AND vegflokkun IN ('8', '12')
+    )
+"""
+
+[[providers.layers]]
+name = "constituencies"
+geometry_fieldname = "geom"
+geometry_type = "Polygon"
+dont_simplify = true
+id_fieldname = "id"
+sql = """
+  SELECT
+    id,
+    nafnfitju
+      AS constituency,
+    ST_AsBinary(
+      ST_SimplifyPreserveTopology(
+        geom,
+        CASE !ZOOM!
+          WHEN  5 THEN  1500
+          WHEN  6 THEN  1000
+          WHEN  7 THEN   350
+          WHEN  8 THEN   200
+          WHEN  9 THEN   100
+          WHEN 10 THEN    50
+          WHEN 11 THEN    25
+          WHEN 12 THEN    15
+        END
+      )
+    )
+      AS geom
+  FROM
+    constituencies
+  WHERE
+    geom && !BBOX!
+"""
+
+[[providers.layers]]
+name = "districts"
+geometry_fieldname = "geom"
+geometry_type = "Polygon"
+dont_simplify = true
+id_fieldname = "id"
+sql = """
+  SELECT
+    id,
+    sveitarfelag
+      AS municipality,
+    kjordaemi
+      AS constituency,
+    kjorstadur
+      AS polling_place,
+    ST_AsBinary(
+      ST_SimplifyPreserveTopology(
+        geom,
+        CASE !ZOOM!
+          WHEN  5 THEN  1500
+          WHEN  6 THEN  1000
+          WHEN  7 THEN   350
+          WHEN  8 THEN   200
+          WHEN  9 THEN   100
+          WHEN 10 THEN    50
+          WHEN 11 THEN    25
+          WHEN 12 THEN    15
+        END
+      )
+    )
+      AS geom
+  FROM
+    districts
+  WHERE
+    geom && !BBOX!
+"""
+
+[[providers.layers]]
+name = "isochrones"
+geometry_fieldname = "geom"
+geometry_type = "Polygon"
+dont_simplify = true
+id_fieldname = "id"
+sql = """
+  SELECT
+    id,
+    contour
+      AS time,
+    kjordaemi
+      AS constituency,
+    kjorstadur
+      AS polling_place,
+    sveitarfelag
+      AS municipality,
+    ST_AsBinary(geom)
+      AS geom
+  FROM
+    isochrones
+  WHERE
+    geom && !BBOX!
+  ORDER BY
+    time
+      DESC
+"""
+
+[[providers.layers]]
+name = "polling_places"
+geometry_fieldname = "geom"
+dont_simplify = true
+id_fieldname = "id"
+sql = """
+  SELECT
+    id,
+    kjorstadur
+      AS polling_place,
+    kjordaemi
+      AS constituency,
+    ST_AsBinary(geom)
+      AS geom
+  FROM
+    polling_places
+  WHERE
+    geom && !BBOX!
+"""
+
+[[maps]]
+name = "election2021"
+bounds = [-24.532681, 63.295769, -13.494616, 66.56644]
+center = [-21.940285, 64.146745, 11.0]
+
+  [[maps.layers]]
+  provider_layer = "election2021.coastline"
+  min_zoom = 5
+  max_zoom = 12
+
+  [[maps.layers]]
+  provider_layer = "election2021.roads"
+  min_zoom = 6
+  max_zoom = 12
+
+  [[maps.layers]]
+  provider_layer = "election2021.constituencies"
+  min_zoom = 5
+  max_zoom = 9
+  dont_simplify = true
+
+  [[maps.layers]]
+  provider_layer = "election2021.districts"
+  min_zoom = 10
+  max_zoom = 12
+  dont_simplify = true
+
+  [[maps.layers]]
+  provider_layer = "election2021.isochrones"
+  min_zoom = 5
+  max_zoom = 12
+  dont_simplify = true
+
+  [[maps.layers]]
+  provider_layer = "election2021.polling_places"
+  min_zoom = 10
+  max_zoom = 12

--- a/map/index.html
+++ b/map/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<head>
+  <title>Kjörstaðir 2021</title>
+  <link href="https://unpkg.com/maplibre-gl@1.15.2/dist/maplibre-gl.css" rel="stylesheet">
+  <style>
+    html, body { margin: 0; padding: 0 }
+    #map { height: 100vh; width: 100vw }
+  </style>
+</head>
+<body>
+  <script src="https://unpkg.com/maplibre-gl@1.15.2/dist/maplibre-gl.js"></script>
+  <div id="map"></div>
+  <script>
+    var map = new maplibregl.Map({
+        container: "map",
+        style: "style.json",
+        minZoom: 5,
+        maxZoom: 16,
+        maxBounds: [-40, 50, 0, 80],
+        hash: true,
+    });
+    map.addControl(new maplibregl.NavigationControl());
+    map.addControl(new maplibregl.ScaleControl());
+    map.addControl(new maplibregl.FullscreenControl({
+      container: document.querySelector("body")
+    }));
+  </script>
+</body>
+</html>

--- a/map/style.json
+++ b/map/style.json
@@ -1,0 +1,153 @@
+{
+  "version": 8,
+  "name": "Election 2021",
+  "center": [
+    -21.9251,
+    64.1381
+  ],
+  "zoom": 11,
+  "sources": {
+    "election2021": {
+      "type": "vector",
+      "url": "http://localhost:8080/capabilities/election2021.json"
+    }
+  },
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#002c3d"
+      }
+    },
+    {
+      "id": "coastline",
+      "type": "fill",
+      "source": "election2021",
+      "source-layer": "coastline",
+      "paint": {
+        "fill-color": "#001f2b"
+      }
+    },
+    {
+      "id": "isochrones",
+      "type": "fill",
+      "source": "election2021",
+      "source-layer": "isochrones",
+      "paint": {
+        "fill-color": [
+          "match",
+          [
+            "get",
+            "time"
+          ],
+          5,
+          "#ffffff",
+          10,
+          "#d6dde0",
+          15,
+          "#b8c4c9",
+          20,
+          "#99abb1",
+          25,
+          "#7b929c",
+          "rgba(0, 0, 0, 0)"
+        ]
+      }
+    },
+    {
+      "id": "roads",
+      "type": "line",
+      "source": "election2021",
+      "source-layer": "roads",
+      "paint": {
+        "line-color": "#5F7782",
+        "line-opacity": 0.6,
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              10,
+              1
+            ],
+            [
+              11,
+              0.5
+            ],
+            [
+              17,
+              5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "constituencies",
+      "type": "line",
+      "source": "election2021",
+      "source-layer": "constituencies",
+      "layout": {
+        "visibility": "none"
+      },
+      "paint": {
+        "line-color": "#002c3d",
+        "line-opacity": 0.5,
+        "line-width": 1
+      }
+    },
+    {
+      "id": "districts",
+      "type": "line",
+      "source": "election2021",
+      "source-layer": "districts",
+      "paint": {
+        "line-color": "#002c3d",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 0.1,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              17,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "polling_places",
+      "type": "circle",
+      "source": "election2021",
+      "source-layer": "polling_places",
+      "paint": {
+        "circle-radius": {
+          "base": 1,
+          "stops": [
+            [
+              7,
+              1
+            ],
+            [
+              12,
+              2
+            ],
+            [
+              22,
+              50
+            ]
+          ]
+        },
+        "circle-color": "#002c3d"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I've added a vector map of your isochrone walking distances data: a map of Iceland from zoom 5 to 12 — plus overzooming means the map goes to zoom 16. Full details are in `map/README.md`.

It uses Tegola to render the tiles. Tegola can [seed a full tile cache](https://tegola.io/documentation/cache-seeding-and-purging/), and those files can be uploaded to a static file server so that this could be deployed to the outside world. It should like something like this:

![Screenshot of the vector map](https://user-images.githubusercontent.com/48392/142690018-fc1bfea9-7067-48ed-9ccf-4b96251c7eb2.png)

A coupld of things are missing:

- Constituency borders are in the tiles but not shown on the map (no style)
- Nothing's labelled — no polling place names are shown, for example
- No legend