### PR TITLE
Add labels for polling places

### DIFF
--- a/map/election2021.toml
+++ b/map/election2021.toml
@@ -17,7 +17,6 @@ srid = 3857
 name = "coastline"
 geometry_fieldname = "geom"
 geometry_type = "Polygon"
-dont_simplify = true
 id_fieldname = "id"
 sql = """
   SELECT
@@ -48,7 +47,6 @@ sql = """
 name = "roads"
 geometry_fieldname = "geom"
 geometry_type = "LineString"
-dont_simplify = true
 id_fieldname = "id"
 sql = """
   SELECT
@@ -90,7 +88,6 @@ sql = """
 name = "constituencies"
 geometry_fieldname = "geom"
 geometry_type = "Polygon"
-dont_simplify = true
 id_fieldname = "id"
 sql = """
   SELECT
@@ -123,7 +120,6 @@ sql = """
 name = "districts"
 geometry_fieldname = "geom"
 geometry_type = "Polygon"
-dont_simplify = true
 id_fieldname = "id"
 sql = """
   SELECT
@@ -160,7 +156,6 @@ sql = """
 name = "isochrones"
 geometry_fieldname = "geom"
 geometry_type = "Polygon"
-dont_simplify = true
 id_fieldname = "id"
 sql = """
   SELECT
@@ -187,7 +182,6 @@ sql = """
 [[providers.layers]]
 name = "polling_places"
 geometry_fieldname = "geom"
-dont_simplify = true
 id_fieldname = "id"
 sql = """
   SELECT

--- a/map/election2021.toml
+++ b/map/election2021.toml
@@ -1,6 +1,6 @@
 [cache]
 type = "file"
-basepath = "./map/cache/tiles"
+basepath = "./cache/tiles"
 max_zoom = 12
 
 [[providers]]

--- a/map/style.json
+++ b/map/style.json
@@ -1,7 +1,7 @@
 {
   "version": 8,
   "name": "Election 2021",
-  "glyphs": "http://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
+  "glyphs": "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
   "center": [
     -21.9251,
     64.1381

--- a/map/style.json
+++ b/map/style.json
@@ -1,6 +1,7 @@
 {
   "version": 8,
   "name": "Election 2021",
+  "glyphs": "http://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
   "center": [
     -21.9251,
     64.1381
@@ -142,11 +143,50 @@
             ],
             [
               22,
-              50
+              35
             ]
           ]
         },
         "circle-color": "#002c3d"
+      }
+    },
+    {
+      "id": "polling_places_labels",
+      "type": "symbol",
+      "source": "election2021",
+      "source-layer": "polling_places",
+      "layout": {
+        "text-font": [
+          "Open Sans Italic"
+        ],
+        "text-field": "{polling_place}",
+        "text-max-width": 4,
+        "text-justify": "auto",
+        "text-radial-offset": 0.5,
+        "text-variable-anchor": [
+          "bottom",
+          "left",
+          "right"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          10,
+          12,
+          16,
+          20
+        ]
+      },
+      "paint": {
+        "text-halo-color": "#f4f4ee",
+        "text-halo-width": 1,
+        "text-halo-blur": 1,
+        "text-color": "#002c3d"
       }
     }
   ]


### PR DESCRIPTION
This adds the names of polling places as labels from zoom 9 onwards. It uses the Open Sans font from the OpenMapTiles server at `fonts.openmaptiles.org` (see the [openmaptiles/fonts](https://github.com/openmaptiles/fonts) repo). At zoom 11 it looks like this:

![Polling place labels over Reykjavík at zoom 11](https://user-images.githubusercontent.com/48392/143134710-27ef51dc-3471-460b-b38b-f24bebe81d0d.png)
s.